### PR TITLE
Fix: Correct image loading for Duck Clicker, Meme Cavern, and Cube

### DIFF
--- a/duck_clicker.js
+++ b/duck_clicker.js
@@ -7,6 +7,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // DOM Elements
     const clickableDuckV2 = document.getElementById('clickableDuckV2');
+    if (clickableDuckV2) { clickableDuckV2.src = duckClosed; }
+
+    // Implement Click Animation:
+    if (clickableDuckV2) {
+        clickableDuckV2.addEventListener('mousedown', () => {
+            clickableDuckV2.src = duckOpen;
+            // Play quack sound if enabled (existing logic)
+            if (isClickerQuackEnabled && clickerQuackSound) {
+                clickerQuackSound.currentTime = 0; // Rewind to start
+                clickerQuackSound.play().catch(error => console.error("Error playing quack sound:", error));
+            }
+        });
+    }
+
+    if (clickableDuckV2) {
+        clickableDuckV2.addEventListener('mouseup', () => {
+            clickableDuckV2.src = duckClosed;
+        });
+    }
+
     const qpAmountDisplay = document.getElementById('qpAmount');
     const qpPerSecondDisplay = document.getElementById('qpPerSecond');
     const qpPerClickDisplay = document.getElementById('qpPerClick');
@@ -384,6 +404,54 @@ document.addEventListener('DOMContentLoaded', () => {
     }).filter(id => id !== null); // Filter out any nulls from parsing errors
 
     let youtubeMemes = [];
+
+    // Functions for YouTube Meme Cavern
+    function displayYoutubeMeme(videoId) {
+        const container = document.getElementById('youtubeLinksContainer');
+        if (container && videoId) {
+            const memeDiv = document.createElement('div');
+            memeDiv.className = 'memeDiv'; // For styling & structure
+
+            const iframe = document.createElement('iframe');
+            iframe.src = `https://www.youtube.com/embed/${videoId}`;
+            iframe.width = "560"; // Standard 16:9, can be styled with CSS later
+            iframe.height = "315";
+            iframe.frameBorder = "0";
+            iframe.allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture";
+            iframe.allowFullscreen = true;
+
+            memeDiv.appendChild(iframe);
+            container.appendChild(memeDiv);
+        }
+    }
+
+    function updateMemeCavern() {
+        const container = document.getElementById('youtubeLinksContainer');
+        if (!container) {
+            console.error('Meme Cavern container not found!');
+            return;
+        }
+        container.innerHTML = ''; // Clear previous memes to prevent duplication
+
+        // Determine how many memes to show based on playerLevel
+        const memesToShow = Math.min(playerLevel + 5, youtubeVideoIDs.length);
+
+        for (let i = 0; i < memesToShow; i++) {
+            if (youtubeVideoIDs[i]) {
+                displayYoutubeMeme(youtubeVideoIDs[i]);
+            }
+        }
+    }
+
+    // Event listener for Meme Cavern Tab
+    const memeCavernTabButton = document.querySelector('.tab-link[onclick*="memeCavernTab"]');
+    if (memeCavernTabButton) {
+        memeCavernTabButton.addEventListener('click', () => {
+            updateMemeCavern();
+        });
+    } else {
+        console.error('Meme Cavern tab button not found for event listener.');
+    }
 
     // Game State Variables
     let qp = 0;

--- a/index.html
+++ b/index.html
@@ -378,12 +378,12 @@
             background-position: center;
             opacity: 0.8;
         }
-        .front  { transform: rotateY(0deg) translateZ(50px); }
-        .back   { transform: rotateY(180deg) translateZ(50px); }
-        .right  { transform: rotateY(90deg) translateZ(50px); }
-        .left   { transform: rotateY(-90deg) translateZ(50px); }
-        .top    { transform: rotateX(90deg) translateZ(50px); }
-        .bottom { transform: rotateX(-90deg) translateZ(50px); }
+        .front  { transform: rotateY(0deg) translateZ(50px); background-image: url('duck_open.png'); }
+        .back   { transform: rotateY(180deg) translateZ(50px); background-image: url('duck_closed.png'); }
+        .right  { transform: rotateY(90deg) translateZ(50px); background-image: url('duck_closed.png'); }
+        .left   { transform: rotateY(-90deg) translateZ(50px); background-image: url('duck_closed.png'); }
+        .top    { transform: rotateX(90deg) translateZ(50px); background-image: url('duck_closed.png'); }
+        .bottom { transform: rotateX(-90deg) translateZ(50px); background-image: url('duck_closed.png'); }
         @keyframes spin {
             0% { transform: translateZ(-50px) rotateX(0deg) rotateY(0deg); }
             100% { transform: translateZ(-50px) rotateX(360deg) rotateY(360deg); }


### PR DESCRIPTION
This commit addresses several image and content loading issues:

1.  **Duck Clicker Image:**
    - The main clickable duck image (`clickableDuckV2`) was not displaying.
    - Modified `duck_clicker.js` to set its `src` attribute to the `duckClosed` base64 image on load.
    - Added `mousedown` and `mouseup` event listeners to animate the duck to `duckOpen` and back to `duckClosed` on click, providing visual feedback.

2.  **Meme Cavern:**
    - YouTube embeds in the "Meme Cavern" tab were not displaying.
    - Added/updated logic in `duck_clicker.js` (`updateMemeCavern` and `displayYoutubeMeme` functions) to dynamically create `<iframe>` embeds for YouTube videos.
    - These memes are now loaded and displayed when the "Meme Cavern" tab is clicked.
    - The number of memes shown is based on `playerLevel`.
    - Known limitations: Memes do not auto-refresh on level-up if the tab isn't active or on game load; the tab must be clicked to see updates.

3.  **Duck Cube Images:**
    - The faces of the 3D spinning duck cube were not displaying images.
    - Updated the CSS in `index.html` to set the `background-image` property for the cube faces.
    - The front face now uses `duck_open.png`, and all other faces (back, top, bottom, left, right) use `duck_closed.png`.

These changes restore the intended visual and interactive elements to the affected components of the page.