### PR TITLE
Fix: Correct image loading for duck clicker

### DIFF
--- a/duck_clicker.js
+++ b/duck_clicker.js
@@ -7,12 +7,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // DOM Elements
     const clickableDuckV2 = document.getElementById('clickableDuckV2');
-    if (clickableDuckV2) { clickableDuckV2.src = duckClosed; }
+    if (clickableDuckV2) { clickableDuckV2.src = 'duck_closed.png'; }
 
     // Implement Click Animation:
     if (clickableDuckV2) {
         clickableDuckV2.addEventListener('mousedown', () => {
-            clickableDuckV2.src = duckOpen;
+            clickableDuckV2.src = 'duck_open.png';
             // Play quack sound if enabled (existing logic)
             if (isClickerQuackEnabled && clickerQuackSound) {
                 clickerQuackSound.currentTime = 0; // Rewind to start
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (clickableDuckV2) {
         clickableDuckV2.addEventListener('mouseup', () => {
-            clickableDuckV2.src = duckClosed;
+            clickableDuckV2.src = 'duck_closed.png';
         });
     }
 


### PR DESCRIPTION
The clickable duck in the Duck Clicker game was previously using tiny base64 encoded images (13x11 pixels) defined in duck.js. This commit updates duck_clicker.js to use the actual image files ('duck_open.png' and 'duck_closed.png') for the clickable duck.

This change ensures the main duck image displays as intended, using the larger, more appropriate graphics.

The base64 variable `duckOpen` from `duck.js` is still used by the Pong game for its ball image, so it has been retained. The `duckClosed` base64 variable from `duck.js` appears to be unused but was not removed in this commit to keep the scope focused on fixing the clicker image.